### PR TITLE
Fix/favorites charts

### DIFF
--- a/assets/flutter_i18n/en.json
+++ b/assets/flutter_i18n/en.json
@@ -47,6 +47,9 @@
   "favorites_nopopulartimes": "No popular times available for this place.",
   "favorites_currentpopularity": "Current popularity:",
   "favorites_placeclosed": "Place closed this day",
+  "favorites_usual_popularity_text1": "This place usual popularity is",
+  "favorites_usual_popularity_text2": "between",
+  "favorites_usual_popularity_text3": "and",
 
   "day_1": "Monday",
   "day_2": "Tuesday",

--- a/assets/flutter_i18n/fr.json
+++ b/assets/flutter_i18n/fr.json
@@ -47,6 +47,9 @@
   "favorites_nopopulartimes": "Ce lieu ne possède pas de données d'affluence.",
   "favorites_currentpopularity": "Affluence actuelle :",
   "favorites_placeclosed": "Lieu fermé en ce jour",
+  "favorites_usual_popularity_text1": "Lieu habituellement rempli à",
+  "favorites_usual_popularity_text2": "entre",
+  "favorites_usual_popularity_text3": "et",
 
   "day_1": "Lundi",
   "day_2": "Mardi",
@@ -54,5 +57,5 @@
   "day_4": "Jeudi",
   "day_5": "Vendredi",
   "day_6": "Samedi",
-  "day_7": "Dimanche"
+  "day_7": "Dimanche",
 }

--- a/lib/components/favorites/FavoritePanelState.dart
+++ b/lib/components/favorites/FavoritePanelState.dart
@@ -1,7 +1,9 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:charts_flutter/flutter.dart' as charts;
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:pandemia/data/database/models/Favorite.dart';
 import 'package:pandemia/data/populartimes/parser/parser.dart';
 import 'package:pandemia/data/populartimes/payloads/populartimes.dart';
@@ -32,6 +34,24 @@ class FavoritePanelState extends State<FavoritePanel> {
   void initState () {
     future = Parser.getPopularTimes(place);
     super.initState();
+  }
+
+  _onSelectionChanged(charts.SelectionModel model) {
+    final CrowdRate selectedDatum = model.selectedDatum[0].datum as CrowdRate;
+    if (selectedDatum.rate != 0) {
+      String message = FlutterI18n.translate(context, "favorites_usual_popularity_text1") +
+          " ${selectedDatum.rate}% " + FlutterI18n.translate(context, "favorites_usual_popularity_text2") +
+          " ${selectedDatum.hour} " + FlutterI18n.translate(context, "favorites_usual_popularity_text3") +
+          " ${int.parse(selectedDatum.hour.substring(0, selectedDatum.hour.length-1))+1}h.";
+
+      Fluttertoast.showToast(
+          msg: message,
+          toastLength: Toast.LENGTH_SHORT,
+          gravity: ToastGravity.BOTTOM,
+          timeInSecForIosWeb: 2,
+          fontSize: 16.0
+      );
+    }
   }
 
   @override
@@ -106,7 +126,7 @@ class FavoritePanelState extends State<FavoritePanel> {
         for (var weekday in times.getOrderedKeys()) {
           var weekstats = times.stats[weekday];
           List<Widget> widgets = [
-            SimpleBarChart.fromPopularTimes ( weekstats.times ),
+            SimpleBarChart.fromPopularTimes ( weekstats.times, _onSelectionChanged ),
             Container (
               padding: EdgeInsets.only(left: 15, top: 5),
               child: Text(

--- a/lib/utils/charts/barChart.dart
+++ b/lib/utils/charts/barChart.dart
@@ -22,6 +22,11 @@ class SimpleBarChart extends StatelessWidget {
     return new charts.BarChart(
       seriesList,
       animate: animate,
+      behaviors: [
+        new charts.InitialSelection(selectedDataConfig: [
+          new charts.SeriesDatumConfig<String>("Crowds", "${DateTime.now().hour}h")
+        ])
+      ],
       primaryMeasureAxis:
         new charts.NumericAxisSpec(renderSpec: new charts.NoneRenderSpec()),
       domainAxis: new charts.OrdinalAxisSpec(

--- a/lib/utils/charts/barChart.dart
+++ b/lib/utils/charts/barChart.dart
@@ -1,4 +1,5 @@
 import 'package:charts_flutter/flutter.dart' as charts;
+import 'package:charts_flutter/flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:pandemia/utils/CustomPalette.dart';
 
@@ -38,6 +39,9 @@ class SimpleBarChart extends StatelessWidget {
           tickProviderSpec:
             new charts.StaticOrdinalTickProviderSpec(
                 <charts.TickSpec<String>>[
+                  new charts.TickSpec('1h'),
+                  new charts.TickSpec('3h'),
+                  new charts.TickSpec('5h'),
                   new charts.TickSpec('7h'),
                   new charts.TickSpec('9h'),
                   new charts.TickSpec('11h'),

--- a/lib/utils/charts/barChart.dart
+++ b/lib/utils/charts/barChart.dart
@@ -7,12 +7,14 @@ import 'package:pandemia/utils/CustomPalette.dart';
 class SimpleBarChart extends StatelessWidget {
   final List<charts.Series> seriesList;
   final bool animate;
+  final Function onTouchCallback;
 
-  SimpleBarChart(this.seriesList, {this.animate});
+  SimpleBarChart(this.seriesList, this.onTouchCallback, {this.animate});
 
-  factory SimpleBarChart.fromPopularTimes(List<List<int>> times) {
+  factory SimpleBarChart.fromPopularTimes(List<List<int>> times, Function onTouchCallback) {
     return new SimpleBarChart(
       _createDataFromPopularTimes(times),
+      onTouchCallback,
       animate: true
     );
   }
@@ -26,6 +28,12 @@ class SimpleBarChart extends StatelessWidget {
         new charts.InitialSelection(selectedDataConfig: [
           new charts.SeriesDatumConfig<String>("Crowds", "${DateTime.now().hour}h")
         ])
+      ],
+      selectionModels: [
+        new charts.SelectionModelConfig(
+          type: charts.SelectionModelType.info,
+          changedListener: this.onTouchCallback
+        )
       ],
       primaryMeasureAxis:
         new charts.NumericAxisSpec(renderSpec: new charts.NoneRenderSpec()),

--- a/lib/utils/charts/barChart.dart
+++ b/lib/utils/charts/barChart.dart
@@ -1,5 +1,4 @@
 import 'package:charts_flutter/flutter.dart' as charts;
-import 'package:charts_flutter/flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:pandemia/utils/CustomPalette.dart';
 

--- a/lib/utils/charts/popularityChart.dart
+++ b/lib/utils/charts/popularityChart.dart
@@ -22,29 +22,23 @@ class PopularityChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return new Container (
-      width: 30,
-      height: 30,
-      child: Stack (
-        children: <Widget>[
-          Container (
-            width: 30,
-            height: 30,
-            transform: Matrix4.translationValues(7, 0, 0),
-            child: Text("$rate%", style: TextStyle(fontSize: 14, color: CustomPalette.text[400])),
-          ),
-
-          Container (
-            width: 30,
-            height: 40,
-            transform: Matrix4.translationValues(-10, 0, 0),
-            child: charts.PieChart(
-                seriesList,
-                animate: animate,
-                defaultRenderer: new charts.ArcRendererConfig(
-                    arcWidth: 2, startAngle: pi, arcLength: 2*pi)),
-          ),
-        ],
-      ),
+      child: Column (
+          children: <Widget>[
+            Container (
+              transform: Matrix4.translationValues(0, 10, 0),
+              child: Text("$rate%", style: TextStyle(fontSize: 12, color: CustomPalette.text[400],)),
+            ),
+            Container (
+              width: 40,
+              height: 40,
+              transform: Matrix4.translationValues(-10, -5, 0),
+              child: charts.PieChart(
+                  seriesList,
+                  animate: animate,
+                  defaultRenderer: new charts.ArcRendererConfig(
+                      arcWidth: 2, startAngle: pi, arcLength: 2*pi)),
+            )
+          ]),
     );
   }
 

--- a/lib/utils/charts/popularityChart.dart
+++ b/lib/utils/charts/popularityChart.dart
@@ -46,10 +46,10 @@ class PopularityChart extends StatelessWidget {
     var value = rate > 100 ? 100 : rate;
     final data =
       value == 100 ?
-      [new GaugeSegment('Popularity', value)] :
+      [new GaugeSegment('Popularity', value, charts.MaterialPalette.red.shadeDefault)] :
       [
-        new GaugeSegment('Popularity', value),
-        new GaugeSegment('Space', 100 - value),
+        new GaugeSegment('Popularity', value, charts.MaterialPalette.blue.shadeDefault),
+        new GaugeSegment('Space', 100 - value, charts.MaterialPalette.blue.makeShades(5)[3]),
       ];
 
     return [
@@ -57,6 +57,7 @@ class PopularityChart extends StatelessWidget {
         id: 'Segments',
         domainFn: (GaugeSegment segment, _) => segment.segment,
         measureFn: (GaugeSegment segment, _) => segment.size,
+        colorFn: (GaugeSegment segment, _) => segment.color,
         data: data,
       )
     ];
@@ -67,6 +68,7 @@ class PopularityChart extends StatelessWidget {
 class GaugeSegment {
   final String segment;
   final int size;
+  final charts.Color color;
 
-  GaugeSegment(this.segment, this.size);
+  GaugeSegment(this.segment, this.size, this.color);
 }

--- a/lib/utils/charts/popularityChart.dart
+++ b/lib/utils/charts/popularityChart.dart
@@ -44,10 +44,13 @@ class PopularityChart extends StatelessWidget {
 
   static List<charts.Series<GaugeSegment, String>> _createData(int rate) {
     var value = rate > 100 ? 100 : rate;
-    final data = [
-      new GaugeSegment('Popularity', value),
-      new GaugeSegment('Space', 100 - value),
-    ];
+    final data =
+      value == 100 ?
+      [new GaugeSegment('Popularity', value)] :
+      [
+        new GaugeSegment('Popularity', value),
+        new GaugeSegment('Space', 100 - value),
+      ];
 
     return [
       new charts.Series<GaugeSegment, String>(

--- a/lib/utils/charts/popularityChart.dart
+++ b/lib/utils/charts/popularityChart.dart
@@ -49,9 +49,10 @@ class PopularityChart extends StatelessWidget {
   }
 
   static List<charts.Series<GaugeSegment, String>> _createData(int rate) {
+    var value = rate > 100 ? 100 : rate;
     final data = [
-      new GaugeSegment('Popularity', rate),
-      new GaugeSegment('Space', 100 - rate),
+      new GaugeSegment('Popularity', value),
+      new GaugeSegment('Space', 100 - value),
     ];
 
     return [


### PR DESCRIPTION
- All time ticks are displayed for places with extended popularity times;
- Correctly displaying popularity rates >= 100;
- Automatically selecting the current popularity time statistic;
- Other statistics are now selectable.

It seems that Google displays its popularity times not from 0h to 23h, but from 4h to 3h, don't ask me why...

---
<img src="https://user-images.githubusercontent.com/11993538/87177027-43d6d300-c2db-11ea-8dff-49c53bccd49b.png" width="300"/>
